### PR TITLE
feature/22-99: подключение api лидерборда

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -28,12 +28,12 @@ function App() {
 
         <Route element={<Authorization requireAuth />}>
           <Route path={RoutesNameList.Profile} element={<Profile />} />
+          <Route path={RoutesNameList.Leaderboard} element={<Leaderboard />} />
         </Route>
 
         <Route path={RoutesNameList.Main} element={<MainPage />} />
         <Route path={RoutesNameList.Forum} element={<Forum />} />
         <Route path={RoutesNameList.Topic} element={<Topic />} />
-        <Route path={RoutesNameList.Leaderboard} element={<Leaderboard />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </MainLayout>

--- a/packages/client/src/api/leaderboard/index.ts
+++ b/packages/client/src/api/leaderboard/index.ts
@@ -2,13 +2,13 @@ import { RATING_FIELD_NAME, TEAM_NAME } from '../../constant'
 import { BaseApi } from '../base'
 import { HttpMethod } from '../constants'
 import type {
-  AddToLeaderboardPayload,
+  LeaderboardRecordData,
   LeaderboardResponse,
   RequestLeaderboardPayload,
 } from './types'
 
 class LeaderboardApi extends BaseApi {
-  addToLeaderboard = async (payload: AddToLeaderboardPayload) =>
+  addToLeaderboard = async (payload: LeaderboardRecordData) =>
     this.createRequest(`${this.baseUrl}`, {
       method: HttpMethod.POST,
       data: {

--- a/packages/client/src/api/leaderboard/index.ts
+++ b/packages/client/src/api/leaderboard/index.ts
@@ -9,7 +9,7 @@ import type {
 
 class LeaderboardApi extends BaseApi {
   addToLeaderboard = async (payload: LeaderboardRecordData) =>
-    this.createRequest(`${this.baseUrl}`, {
+    this.createRequest(this.baseUrl, {
       method: HttpMethod.POST,
       data: {
         data: payload,

--- a/packages/client/src/api/leaderboard/index.ts
+++ b/packages/client/src/api/leaderboard/index.ts
@@ -21,7 +21,7 @@ class LeaderboardApi extends BaseApi {
 
   requestLeaderboard = async ({
     cursor = 0,
-    limit = 50,
+    limit = 20,
   }: RequestLeaderboardPayload) =>
     this.createRequest<LeaderboardResponse>(`${this.baseUrl}/${TEAM_NAME}`, {
       method: HttpMethod.POST,

--- a/packages/client/src/api/leaderboard/index.ts
+++ b/packages/client/src/api/leaderboard/index.ts
@@ -11,18 +11,21 @@ class LeaderboardApi extends BaseApi {
   addToLeaderboard = async (payload: AddToLeaderboardPayload) =>
     this.createRequest(`${this.baseUrl}`, {
       method: HttpMethod.POST,
-      data: payload,
+      data: {
+        data: payload,
+        ratingFieldName: RATING_FIELD_NAME,
+        teamName: TEAM_NAME,
+      },
       shouldParseResponse: false,
     })
 
   requestLeaderboard = async ({
-    ratingFieldName = RATING_FIELD_NAME,
     cursor = 0,
     limit = 50,
   }: RequestLeaderboardPayload) =>
     this.createRequest<LeaderboardResponse>(`${this.baseUrl}/${TEAM_NAME}`, {
       method: HttpMethod.POST,
-      data: { ratingFieldName, cursor, limit },
+      data: { ratingFieldName: RATING_FIELD_NAME, cursor, limit },
     })
 }
 

--- a/packages/client/src/api/leaderboard/index.ts
+++ b/packages/client/src/api/leaderboard/index.ts
@@ -1,0 +1,29 @@
+import { RATING_FIELD_NAME, TEAM_NAME } from '../../constant'
+import { BaseApi } from '../base'
+import { HttpMethod } from '../constants'
+import type {
+  AddToLeaderboardPayload,
+  LeaderboardResponse,
+  RequestLeaderboardPayload,
+} from './types'
+
+class LeaderboardApi extends BaseApi {
+  addToLeaderboard = async (payload: AddToLeaderboardPayload) =>
+    this.createRequest(`${this.baseUrl}`, {
+      method: HttpMethod.POST,
+      data: payload,
+      shouldParseResponse: false,
+    })
+
+  requestLeaderboard = async ({
+    ratingFieldName = RATING_FIELD_NAME,
+    cursor = 0,
+    limit = 50,
+  }: RequestLeaderboardPayload) =>
+    this.createRequest<LeaderboardResponse>(`${this.baseUrl}/${TEAM_NAME}`, {
+      method: HttpMethod.POST,
+      data: { ratingFieldName, cursor, limit },
+    })
+}
+
+export const leaderboardApi = new LeaderboardApi('leaderboard')

--- a/packages/client/src/api/leaderboard/types.ts
+++ b/packages/client/src/api/leaderboard/types.ts
@@ -1,0 +1,26 @@
+export type LeaderboardRecordData = {
+  id: number
+  username: string
+  score: number
+  avatar: string | null
+}
+
+export type AddToLeaderboardPayload = {
+  data: LeaderboardRecordData
+  ratingFieldName: string
+  teamName: string
+}
+
+export type RequestLeaderboardPayload = {
+  ratingFieldName?: string
+  cursor?: number
+  limit?: number
+}
+
+export type LeaderboardResponse = {
+  data: LeaderboardRecordData
+}[]
+
+export type LeaderboardListRecord = LeaderboardRecordData & {
+  order: number
+}

--- a/packages/client/src/api/leaderboard/types.ts
+++ b/packages/client/src/api/leaderboard/types.ts
@@ -2,9 +2,7 @@ import { RATING_FIELD_NAME } from '../../constant'
 
 export type LeaderboardRecordData = {
   id: number
-  username: string
   [RATING_FIELD_NAME]: number
-  avatar: string | null
 }
 
 export type AddToLeaderboardPayload = LeaderboardRecordData
@@ -19,5 +17,7 @@ export type LeaderboardResponse = {
 }[]
 
 export type LeaderboardListRecord = LeaderboardRecordData & {
+  username: string
+  avatar: string | null
   order: number
 }

--- a/packages/client/src/api/leaderboard/types.ts
+++ b/packages/client/src/api/leaderboard/types.ts
@@ -1,18 +1,15 @@
+import { RATING_FIELD_NAME } from '../../constant'
+
 export type LeaderboardRecordData = {
   id: number
   username: string
-  score: number
+  [RATING_FIELD_NAME]: number
   avatar: string | null
 }
 
-export type AddToLeaderboardPayload = {
-  data: LeaderboardRecordData
-  ratingFieldName: string
-  teamName: string
-}
+export type AddToLeaderboardPayload = LeaderboardRecordData
 
 export type RequestLeaderboardPayload = {
-  ratingFieldName?: string
   cursor?: number
   limit?: number
 }

--- a/packages/client/src/api/leaderboard/types.ts
+++ b/packages/client/src/api/leaderboard/types.ts
@@ -5,8 +5,6 @@ export type LeaderboardRecordData = {
   [RATING_FIELD_NAME]: number
 }
 
-export type AddToLeaderboardPayload = LeaderboardRecordData
-
 export type RequestLeaderboardPayload = {
   cursor?: number
   limit?: number

--- a/packages/client/src/api/user/index.ts
+++ b/packages/client/src/api/user/index.ts
@@ -28,6 +28,11 @@ class UserApi extends BaseApi {
       data: trimData(payload),
       shouldParseResponse: false,
     })
+
+  getUserById = async (id: number) =>
+    this.createRequest<User>(`${this.baseUrl}/${id}`, {
+      method: HttpMethod.GET,
+    })
 }
 
 export const userApi = new UserApi('user')

--- a/packages/client/src/components/Leaderboard/LeaderView/index.css
+++ b/packages/client/src/components/Leaderboard/LeaderView/index.css
@@ -2,7 +2,6 @@
   margin-bottom: 24px;
   height: 70px;
   font-family: var(--font-secondary);
-  display: flex;
   font-size: 18px;
   color: var(--color-text-secondary);
   font-weight: 600;

--- a/packages/client/src/components/Leaderboard/LeaderView/index.tsx
+++ b/packages/client/src/components/Leaderboard/LeaderView/index.tsx
@@ -1,22 +1,27 @@
 import { Avatar } from '../../Avatar'
 import './index.css'
 
-export interface ProfileProps {
+export type LeaderViewProps = {
   order: number
-  avatar: string
+  avatar: string | null
   username: string
   score: number
 }
 
-export function LeaderView(props: ProfileProps) {
+export function LeaderView({
+  order,
+  avatar,
+  score,
+  username,
+}: LeaderViewProps) {
   return (
     <div className="player">
-      <div className="player__number">{props.order}</div>
+      <span className="player__number">{order}</span>
       <div className="player__profile">
-        <Avatar src={props.avatar} className={'player__image'} size="small" />
-        <div className="player__name">{props.username}</div>
+        <Avatar src={avatar ?? ''} className="player__image" size="small" />
+        <p className="player__name">{username}</p>
       </div>
-      <div className="player__score">{props.score}</div>
+      <span className="player__score">{score}</span>
     </div>
   )
 }

--- a/packages/client/src/components/Leaderboard/index.css
+++ b/packages/client/src/components/Leaderboard/index.css
@@ -50,5 +50,6 @@
 }
 
 .board__button {
+  display: block;
   margin-top: 24px;
 }

--- a/packages/client/src/components/Leaderboard/index.css
+++ b/packages/client/src/components/Leaderboard/index.css
@@ -39,7 +39,6 @@
 
 .board__user {
   border-bottom: 1px solid var(--color-text-secondary);
-  margin-bottom: 24px;
   margin-top: 24px;
 }
 
@@ -47,6 +46,7 @@
   width: 372px;
   height: 282px;
   overflow-y: auto;
+  margin-top: 24px;
 }
 
 .board__button {

--- a/packages/client/src/components/Leaderboard/index.tsx
+++ b/packages/client/src/components/Leaderboard/index.tsx
@@ -2,7 +2,7 @@ import { Title } from '../Title'
 import { Link } from '../Link'
 import { LeaderView } from './LeaderView'
 import type { LeaderboardListRecord } from '../../api/leaderboard/types'
-import { RoutesNameList } from '../../constant'
+import { RATING_FIELD_NAME, RoutesNameList } from '../../constant'
 import './index.css'
 
 const title = 'лидерборд'
@@ -32,7 +32,7 @@ export function LeaderboardTable({
             order={user.order}
             avatar={user.avatar}
             username="Вы"
-            score={user.score}
+            score={user[RATING_FIELD_NAME]}
           />
         </div>
       )}

--- a/packages/client/src/components/Leaderboard/index.tsx
+++ b/packages/client/src/components/Leaderboard/index.tsx
@@ -21,9 +21,9 @@ export function LeaderboardTable({
       <Title className="board__title" text={title} />
 
       <div className="board__info">
-        <div>№</div>
-        <div>Игрок</div>
-        <div>Результат</div>
+        <span>№</span>
+        <span>Игрок</span>
+        <span>Результат</span>
       </div>
 
       {user && (

--- a/packages/client/src/components/Leaderboard/index.tsx
+++ b/packages/client/src/components/Leaderboard/index.tsx
@@ -1,7 +1,8 @@
-import { Button } from '../Button'
-import { LeaderView } from './LeaderView'
 import { Title } from '../Title'
+import { Link } from '../Link'
+import { LeaderView } from './LeaderView'
 import type { LeaderboardListRecord } from '../../api/leaderboard/types'
+import { RoutesNameList } from '../../constant'
 import './index.css'
 
 const title = 'лидерборд'
@@ -44,7 +45,12 @@ export function LeaderboardTable({
         })}
       </div>
 
-      <Button className="board__button" text="Начать игру" />
+      <Link
+        className="board__button"
+        text="Начать игру"
+        view="primary"
+        href={RoutesNameList.Game}
+      />
     </div>
   )
 }

--- a/packages/client/src/components/Leaderboard/index.tsx
+++ b/packages/client/src/components/Leaderboard/index.tsx
@@ -1,27 +1,50 @@
-import './index.css'
 import { Button } from '../Button'
 import { LeaderView } from './LeaderView'
 import { Title } from '../Title'
-import { leaderboardList } from './leaderboardList'
+import type { LeaderboardListRecord } from '../../api/leaderboard/types'
+import './index.css'
+
 const title = 'лидерборд'
-export function LeaderboardTable() {
+
+type LeaderboardTableProps = {
+  user?: LeaderboardListRecord | null
+  leaderboardList: LeaderboardListRecord[]
+}
+
+export function LeaderboardTable({
+  user,
+  leaderboardList,
+}: LeaderboardTableProps) {
   return (
     <div className="board">
-      <Title className={'board__title'} text={title} />
+      <Title className="board__title" text={title} />
+
       <div className="board__info">
         <div>№</div>
         <div>Игрок</div>
         <div>Результат</div>
       </div>
-      <div className="board__user">
-        <LeaderView order={8} avatar={''} username={'Вы'} score={278} />
-      </div>
+
+      {user && (
+        <div className="board__user">
+          <LeaderView
+            order={user.order}
+            avatar={user.avatar}
+            username="Вы"
+            score={user.score}
+          />
+        </div>
+      )}
+
       <div className="board__list">
-        {leaderboardList.map(player => (
-          <LeaderView key={player.order} {...player} />
-        ))}
+        {leaderboardList.map(player => {
+          if (player.id !== user?.id) {
+            return <LeaderView key={player.id} {...player} />
+          }
+        })}
       </div>
-      <Button className="board__button" text={'Начать игру'} />
+
+      <Button className="board__button" text="Начать игру" />
     </div>
   )
 }

--- a/packages/client/src/components/Leaderboard/leaderboardList.ts
+++ b/packages/client/src/components/Leaderboard/leaderboardList.ts
@@ -1,8 +1,0 @@
-import { ProfileProps } from './LeaderView'
-
-export const leaderboardList: ProfileProps[] = [
-  { order: 1, avatar: '', username: 'Игрок 111111', score: 520 },
-  { order: 2, avatar: '', username: 'Игрок 2', score: 470 },
-  { order: 3, avatar: '', username: 'Игрок 3', score: 315 },
-  { order: 4, avatar: '', username: 'Игрок 4', score: 310 },
-]

--- a/packages/client/src/components/Link/index.tsx
+++ b/packages/client/src/components/Link/index.tsx
@@ -21,8 +21,6 @@ export const Link: FC<LinkProps> = memo(
       }
     }
 
-    console.log('render', view)
-
     return (
       <RouterLink
         className={classNames('button', `button_view_${view}`, className)}

--- a/packages/client/src/components/Link/index.tsx
+++ b/packages/client/src/components/Link/index.tsx
@@ -1,6 +1,6 @@
 import type { AnchorHTMLAttributes, FC } from 'react'
 import { memo } from 'react'
-import { NavLink as RouterLink } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import classNames from 'classnames'
 import randomClickSound from '../../utils/randomClickSound'
 import '../Button/index.css'
@@ -10,18 +10,22 @@ export type LinkProps = {
   text: string
   view?: 'primary' | 'secondary' | 'ghost'
   withSound?: boolean
+  className?: string
 } & AnchorHTMLAttributes<HTMLAnchorElement>
 
 export const Link: FC<LinkProps> = memo(
-  ({ href, text, view = 'primary', withSound = true, ...props }) => {
+  ({ href, text, view = 'primary', withSound = true, className, ...props }) => {
     function addSound() {
       if (withSound) {
         return randomClickSound
       }
     }
+
+    console.log('render', view)
+
     return (
       <RouterLink
-        className={classNames('button', `button_view_${view}`)}
+        className={classNames('button', `button_view_${view}`, className)}
         to={href}
         onMouseUp={addSound}
         {...props}>

--- a/packages/client/src/constant.ts
+++ b/packages/client/src/constant.ts
@@ -17,3 +17,6 @@ export const regExps = {
 }
 
 export const GENERAL_ERROR = 'Что-то пошло не так'
+
+export const TEAM_NAME = 'cuties-22-naruto-runner'
+export const RATING_FIELD_NAME = 'score'

--- a/packages/client/src/constant.ts
+++ b/packages/client/src/constant.ts
@@ -18,5 +18,5 @@ export const regExps = {
 
 export const GENERAL_ERROR = 'Что-то пошло не так'
 
-export const TEAM_NAME = 'cuties-22-naruto-runner'
+export const TEAM_NAME = '22-cuties-naruto-runner'
 export const RATING_FIELD_NAME = 'score'

--- a/packages/client/src/pages/Leaderboard/index.tsx
+++ b/packages/client/src/pages/Leaderboard/index.tsx
@@ -1,10 +1,33 @@
-import { Fragment } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useAppDispatch, useAppSelector } from '../../store'
+import { selectUserData } from '../../store/user/selectors'
+import { selectLeaderboardData } from '../../store/leaderboard/selectors'
+import { requestLeaderboard } from '../../store/leaderboard/thunk'
 import { LeaderboardTable } from '../../components/Leaderboard'
 
 export function Leaderboard() {
+  const dispatch = useAppDispatch()
+  const { user } = useAppSelector(selectUserData)
+  const { leaderboardList, leaderboardError } = useAppSelector(
+    selectLeaderboardData
+  )
+
+  const userRecord = useMemo(() => {
+    return leaderboardList.find(player => player.id === user?.id)
+  }, [leaderboardList, user])
+
+  useEffect(() => {
+    dispatch(requestLeaderboard())
+  }, [dispatch])
+
+  useEffect(() => {
+    if (leaderboardError) {
+      // TODO показать тостъ
+      alert(leaderboardError)
+    }
+  }, [leaderboardError])
+
   return (
-    <Fragment>
-      <LeaderboardTable />
-    </Fragment>
+    <LeaderboardTable user={userRecord} leaderboardList={leaderboardList} />
   )
 }

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -5,15 +5,19 @@ import type { AuthState } from './auth/slice'
 import authReducer from './auth/slice'
 import type { UserState } from './user/slice'
 import userReducer from './user/slice'
+import type { LeaderboardState } from './leaderboard/slice'
+import leaderboardReducer from './leaderboard/slice'
 
 export type AppState = {
   auth: AuthState
   user: UserState
+  leaderboard: LeaderboardState
 }
 
 const appReducer = combineReducers<AppState>({
   auth: authReducer,
   user: userReducer,
+  leaderboard: leaderboardReducer,
 })
 
 export const store = configureStore({

--- a/packages/client/src/store/leaderboard/selectors.ts
+++ b/packages/client/src/store/leaderboard/selectors.ts
@@ -1,0 +1,3 @@
+import type { AppState } from '../index'
+
+export const selectLeaderboardData = (state: AppState) => state.leaderboard

--- a/packages/client/src/store/leaderboard/slice.ts
+++ b/packages/client/src/store/leaderboard/slice.ts
@@ -26,10 +26,7 @@ export const leaderboardSlice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(requestLeaderboard.fulfilled, (state, { payload }) => {
-      state.leaderboardList = payload.map(({ data }, i) => ({
-        ...data,
-        order: i + 1,
-      }))
+      state.leaderboardList = payload
     })
     builder.addMatcher(
       isPending(addToLeaderboard, requestLeaderboard),

--- a/packages/client/src/store/leaderboard/slice.ts
+++ b/packages/client/src/store/leaderboard/slice.ts
@@ -1,0 +1,58 @@
+import {
+  createSlice,
+  isFulfilled,
+  isPending,
+  isRejected,
+} from '@reduxjs/toolkit'
+import { addToLeaderboard, requestLeaderboard } from './thunk'
+import { GENERAL_ERROR } from '../../constant'
+import type { LeaderboardListRecord } from '../../api/leaderboard/types'
+
+export type LeaderboardState = {
+  isLeaderboardLoading: boolean
+  leaderboardError: string | null
+  leaderboardList: LeaderboardListRecord[]
+}
+
+const initialState: LeaderboardState = {
+  isLeaderboardLoading: false,
+  leaderboardError: null,
+  leaderboardList: [],
+}
+
+export const leaderboardSlice = createSlice({
+  name: 'leaderboard',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(requestLeaderboard.fulfilled, (state, { payload }) => {
+      state.leaderboardList = payload.map(({ data }, i) => ({
+        ...data,
+        order: i + 1,
+      }))
+    })
+    builder.addMatcher(
+      isPending(addToLeaderboard, requestLeaderboard),
+      state => {
+        state.isLeaderboardLoading = true
+        state.leaderboardError = null
+      }
+    )
+    builder.addMatcher(
+      isFulfilled(addToLeaderboard, requestLeaderboard),
+      state => {
+        state.isLeaderboardLoading = false
+        state.leaderboardError = null
+      }
+    )
+    builder.addMatcher(
+      isRejected(addToLeaderboard, requestLeaderboard),
+      (state, { error }) => {
+        state.isLeaderboardLoading = false
+        state.leaderboardError = error.message ?? GENERAL_ERROR
+      }
+    )
+  },
+})
+
+export default leaderboardSlice.reducer

--- a/packages/client/src/store/leaderboard/thunk.ts
+++ b/packages/client/src/store/leaderboard/thunk.ts
@@ -1,17 +1,17 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { leaderboardApi } from '../../api/leaderboard'
 import type {
-  AddToLeaderboardPayload,
+  LeaderboardListRecord,
+  LeaderboardRecordData,
   RequestLeaderboardPayload,
 } from '../../api/leaderboard/types'
-import { LeaderboardListRecord } from '../../api/leaderboard/types'
 import { userApi } from '../../api/user'
-import { User } from '../../api/user/types'
+import type { User } from '../../api/user/types'
 import { updateResourcePath } from '../../utils/updateResourcePath'
 
 export const addToLeaderboard = createAsyncThunk(
   'leaderboard/add',
-  async (payload: AddToLeaderboardPayload) => {
+  async (payload: LeaderboardRecordData) => {
     await leaderboardApi.addToLeaderboard(payload)
   }
 )

--- a/packages/client/src/store/leaderboard/thunk.ts
+++ b/packages/client/src/store/leaderboard/thunk.ts
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { leaderboardApi } from '../../api/leaderboard'
+import type {
+  AddToLeaderboardPayload,
+  RequestLeaderboardPayload,
+} from '../../api/leaderboard/types'
+
+export const addToLeaderboard = createAsyncThunk(
+  'leaderboard/add',
+  async (payload: AddToLeaderboardPayload) => {
+    await leaderboardApi.addToLeaderboard(payload)
+  }
+)
+
+export const requestLeaderboard = createAsyncThunk(
+  'leaderboard/request',
+  async (payload: RequestLeaderboardPayload = {}) => {
+    const table = await leaderboardApi.requestLeaderboard(payload)
+    return table
+  }
+)

--- a/packages/client/src/store/leaderboard/thunk.ts
+++ b/packages/client/src/store/leaderboard/thunk.ts
@@ -4,6 +4,10 @@ import type {
   AddToLeaderboardPayload,
   RequestLeaderboardPayload,
 } from '../../api/leaderboard/types'
+import { LeaderboardListRecord } from '../../api/leaderboard/types'
+import { userApi } from '../../api/user'
+import { User } from '../../api/user/types'
+import { updateResourcePath } from '../../utils/updateResourcePath'
 
 export const addToLeaderboard = createAsyncThunk(
   'leaderboard/add',
@@ -16,6 +20,24 @@ export const requestLeaderboard = createAsyncThunk(
   'leaderboard/request',
   async (payload: RequestLeaderboardPayload = {}) => {
     const table = await leaderboardApi.requestLeaderboard(payload)
-    return table
+
+    const getUserPromises = table.map(({ data }) =>
+      userApi.getUserById(data.id)
+    )
+
+    const users = await Promise.all(getUserPromises)
+
+    const usersMap = users.reduce((acc, current) => {
+      acc[current.id] = current
+      return acc
+    }, {} as Record<string, User>)
+
+    const mappedTable: LeaderboardListRecord[] = table.map(({ data }, i) => ({
+      ...data,
+      username: usersMap[data.id].login,
+      avatar: updateResourcePath(usersMap[data.id].avatar),
+      order: i + 1,
+    }))
+    return mappedTable
   }
 )


### PR DESCRIPTION
### Какую задачу решаем
- подключаем лидерборд к api
- добавляем хранилище для лидерборда

api предоставляет POST-ручки `/leaderboard` и `/leaderboard/{teamName}`, для работы с ними разработаны два метода:
- `addToLeaderboard` (добавляет `id` текущего игрока и его `score` в базу)
- `requestLeaderboard` (получает список из данных, отправленных в методе `addToLeaderboard`)

Вместе с запросом на сервер уходит кука текущего пользователя, все реквесты по добавлению в таблицу будут привязаны к нему. То есть не получится создать несколько записей в лидерборд с одного пользователя -- они будут перезаписываться, если `score` будет больше последнего значения.

Есть ещё один нюанс: эти ручки принимают и отдают любую независимую структуру данных, и чтобы получить _актуальные_ данные игроков, необходимо запрашивать их по каждому пользователю отдельно. То есть, если в таблице 20 игроков, то делаются дополнительные 20 запросов через `Promise.allSettled`

Если запрос за конкретным юзером упал по какой-либо причине (испорченный айдишник, серверная депрессия, etc), то он не отображается в таблице.

Также нельзя удалить запись из таблицы, она остается там до следующего дропа БД.

